### PR TITLE
Update the email addresses in SUPPORT.md

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: MPL-2.0
 There are a few ways to connect with the Power Grid Model project:
 
 * Submit an issue
-* Send an email to the Technical Steering Committee: <dynamic.grid.calculation@alliander.com>.
+* Send an email to the Technical Steering Committee: <powergridmodel-tsc@lists.lfenergy.org>.
 
 ## How to ask for help, suggest a feature, or give recommendations.
 
@@ -39,7 +39,7 @@ Please refer to this [notebook](https://power-grid-model.readthedocs.io/en/stabl
 ## How to report a security vulnerability
 
 If you think you've found a potential vulnerability in this project, please
-email <dynamic.grid.calculation@alliander.com> to responsibly disclose it.
+email <powergridmodel-tsc@lists.lfenergy.org> to responsibly disclose it.
 
 ## Contributing a fix
 


### PR DESCRIPTION
Update the email addresses in SUPPORT.md to powergridmodel-tsc@lists.lfenergy.org

**Fixes issue**: ` #269

### Changes proposed in this PR include:

> Change the email addresses in SUPPORT.md to [powergridmodel-tsc@lists.lfenergy.org](mailto:powergridmodel-tsc@lists.lfenergy.org)
