### PR TITLE
Add download badges to README.md

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -8,6 +8,8 @@ SPDX-License-Identifier: MPL-2.0
 
 [![License: MPL2.0](https://img.shields.io/badge/License-MPL2.0-informational.svg)](https://github.com/PowerGridModel/.github/blob/main/LICENSE)
 [![OpenSSF Best Practices](https://bestpractices.coreinfrastructure.org/projects/7298/badge)](https://bestpractices.coreinfrastructure.org/projects/7298)
+[![Downloads](https://static.pepy.tech/badge/power-grid-model)](https://pepy.tech/project/power-grid-model)
+[![Downloads](https://static.pepy.tech/badge/power-grid-model/month)](https://pepy.tech/project/power-grid-model)
 
 [![](https://github.com/PowerGridModel/.github/blob/main/artwork/svg/color.svg)](#)
 


### PR DESCRIPTION
cfr. https://github.com/PowerGridModel/power-grid-model/pull/410

Please review the preview in https://github.com/PowerGridModel/.github/tree/feature/download-badges/profile

I thought about changing the setup to more clearly show that the downloads badge refers to the calculation core and not to all repos combined, but I did not find a nice-looking way to do so. I think this suffices as long as it's the only large repo