### PR TITLE
Create COMMITTERS.md

### DIFF
--- a/COMMITTERS.md
+++ b/COMMITTERS.md
@@ -1,0 +1,11 @@
+<!--
+SPDX-FileCopyrightText: 2022 Contributors to the Power Grid Model project <dynamic.grid.calculation@alliander.com>
+
+SPDX-License-Identifier: MPL-2.0
+-->
+
+# Project Contributors
+To view a list of current contributors who actively commit to this project, you can find detailed information [here](https://github.com/PowerGridModel/power-grid-model/graphs/contributors).
+
+For details on our maintainers, recognized Non-Code Contributors, and a record of Historical Contributors, please refer to our governance page [here](https://github.com/PowerGridModel/.github/blob/main/GOVERNANCE.md)
+


### PR DESCRIPTION
For the Power Grid Model to be ready to move from Sandbox stage to Incubation stage, it needs to have a COMMITTERS.md file to define individuals or teams that are responsible for code in a repository; document current project owners and current and emeritus committers. 

For more information see: https://wiki.lfenergy.org/display/HOME/Technical+Project+Lifecycle

**Fixes issue**: `#422`

### Changes proposed in this PR include:

> Here you can elaborate on the chosen solution strategy, which changes did you make and which goal do they serve. Perhaps also which things are you still unsure of.

- Create COMMITTERS.md

