### PR TITLE
Remove the description of release branch.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,11 +13,6 @@ build and upload a new version to PyPI with a unique version number.
 **All the bug fixes will be committed directly into the `main` branch and published in the latest release. 
 No effort will be spent on backporting bug fixes to previous versions!**
 
-Sometimes a `release/` branch will be created temporarily for 
-a big new version with new features and/or breaking changes.
-A push (merge) to the release branch will tigger GitHub Actions to automatically 
-build and upload a new version to PyPI with a unique release-candidate version number (suffix `rc`).
-
 **NOTE: Release candidate versions are for testing only. You should not use them in production!**
 
 ## Actively supported Python versions


### PR DESCRIPTION
Branches with the 'release' string are not supported anymore. In this PR we remove the description of such branches.