### PR TITLE
Update governance.md with new members

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -25,7 +25,7 @@ The TSC consists of the following members:
 1. Werner van Westering
 1. Jonas van den Bogaard
 1. Peter Salemink
-2. Jaap Schouten
+1. Jaap Schouten
 
 Tony Xiang will chair the TSC.
 
@@ -54,8 +54,8 @@ The current maintainers of this project are:
 1. Zhen Wang
 1. Jerry Guo
 1. Santiago Figueroa Manrique
-2. Jaap Schouten
-3. Thijs Baaijen
+1. Jaap Schouten
+1. Thijs Baaijen
 
 Any community member or Contributor can ask a question or raise an issue to the maintainers by logging a GitHub issue.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -25,6 +25,7 @@ The TSC consists of the following members:
 1. Werner van Westering
 1. Jonas van den Bogaard
 1. Peter Salemink
+2. Jaap Schouten
 
 Tony Xiang will chair the TSC.
 
@@ -53,6 +54,8 @@ The current maintainers of this project are:
 1. Zhen Wang
 1. Jerry Guo
 1. Santiago Figueroa Manrique
+2. Jaap Schouten
+3. Thijs Baaijen
 
 Any community member or Contributor can ask a question or raise an issue to the maintainers by logging a GitHub issue.
 


### PR DESCRIPTION
### Changes proposed in this PR include:

Added Jaap Schouten as new member of the Power Grid Model TSC

Added Jaap Schouten and Thijs Baaijen as new maintainers of the Power Grid Model TSC
