### PR TITLE
Add python 3.13 to release schedule

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -33,10 +33,11 @@ For the actively supported versions as of December 2023, the following release c
 | Python version | Currently supported | Scheduled/expected end of active support |
 | -------------- | ------------------- | ---------------------------------------- |
 | Python 3.8     | &#10060;            | 10-January-2024 (dropped)                |
-| Python 3.9     | &#10060;            | 15-July-2024 (dropped)                    |
+| Python 3.9     | &#10060;            | 15-July-2024 (dropped)                   |
 | Python 3.10    | &#9989;             | January 2025 (expected)                  |
 | Python 3.11    | &#9989;             | January 2026 (expected)                  |
 | Python 3.12    | &#9989;             | January 2027 (expected)                  |
+| Python 3.13    | &#9989;             | January 2028 (expected)                  |
 
 Starting with Python 3.10, the expected date of end of active support for a given Python version
 is three years and three months after it comes out.


### PR DESCRIPTION
Python 3.13 will officially be released tomorrow (cfr. https://docs.python.org/3.13/whatsnew/3.13.html )

Since the latest version of Python 3.13 is pretty much final, I think we can/should add it to the `RELEASE.md`.

Please also note the following NOTICE in https://docs.python.org/3.13/whatsnew/3.13.html:

> [PEP 602](https://peps.python.org/pep-0602/) (“Annual Release Cycle for Python”) has been updated to extend the full support (‘bugfix’) period for new releases to two years. This updated policy means that:
> 
>     Python 3.9–3.12 have one and a half years of full support, followed by three and a half years of security fixes.
> 
>     Python 3.13 and later have two years of full support, followed by three years of security fixes.
> 