### PR TITLE
fix: pull requests template fixes doesnt close issue

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-**Fixes issue**: `# name and number of the issue`
+Fixes #issue_number
 
 ### Changes proposed in this PR include:
 


### PR DESCRIPTION
We noticed that a PR with the number filled in, doesn't actually fix it. 
I think this is because of the bold syntax around the fixes. 

The syntax should be "fixes #xx" or "closes #xx"
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue